### PR TITLE
Use latest released version of slim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'benchmark-ips'
 gem 'erubi'
 gem 'haml', '>= 6'
-gem 'slim', git: 'https://github.com/k0kubun/slim', ref: '1176de67cfe70049e0d2556cabfc5e538ca92263' # temple 0.9.1+ support
+gem 'slim', '>= 5'
 gem 'temple', '>= 0.9.1'
 gem 'tilt'


### PR DESCRIPTION
Running on a 13" M2 MacBook Pro.

```
❯ bundle exec ruby run-benchmarks.rb
Warming up --------------------------------------
           erb 4.0.2    51.977k i/100ms
        erubi 1.12.0    54.346k i/100ms
   temple erb 0.10.0    48.613k i/100ms
          haml 6.1.1    49.389k i/100ms
          slim 5.0.0    52.625k i/100ms
Calculating -------------------------------------
           erb 4.0.2    545.532k (± 2.4%) i/s -      2.755M in   5.052736s
        erubi 1.12.0    550.560k (± 2.9%) i/s -      2.772M in   5.038793s
   temple erb 0.10.0    490.742k (± 2.1%) i/s -      2.479M in   5.054329s
          haml 6.1.1    490.020k (± 2.5%) i/s -      2.469M in   5.042808s
          slim 5.0.0    526.295k (± 1.8%) i/s -      2.631M in   5.001253s

Comparison:
        erubi 1.12.0:   550559.9 i/s
           erb 4.0.2:   545532.1 i/s - same-ish: difference falls within error
          slim 5.0.0:   526294.9 i/s - same-ish: difference falls within error
   temple erb 0.10.0:   490741.8 i/s - 1.12x  slower
          haml 6.1.1:   490019.7 i/s - 1.12x  slower

bundle exec ruby run-benchmarks.rb  34.90s user 0.29s system 99% cpu 35.515 total
```
CC @k0kubun @minad 

This PR updates slim to the 5.0.0 release.